### PR TITLE
(sql.init) - add SQL initialize script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # env 
 .env
 .env.local
+.env.*

--- a/src/server/DBConnection.ts
+++ b/src/server/DBConnection.ts
@@ -6,33 +6,36 @@ export class DBConnection {
   private connection: mysql.Connection;
 
   constructor() {
-    this.connection = mysql.createConnection({
+    const connectionOptions = {
       host: process.env.DB_HOST,
       user: process.env.DB_USER,
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
-    });
-
-    // create tables if not exist
-
-    // TODO uncomment when ready
-    /* 
-
+    };
+    if (process.env.DB_PORT) {
+      connectionOptions["port"] = process.env.DB_PORT;
+    }
+    this.connection = mysql.createConnection(connectionOptions);
     this.connect();
+
     const createSQLQueries = fs
       .readFileSync(path.join(__dirname, "/init.sql"))
       .toString();
 
-     this.connection.query(createSQLQueries, (err) => {
-      if (err) {
-        console.error(err);
-      }
-    });
+    const queriesArr = createSQLQueries
+      .split(");")
+      .filter((str) => /\s/.test(str))
+      .map((str) => `${str});`);
 
+    for (const query of queriesArr) {
+      this.connection.query(query, (err) => {
+        if (err) {
+          console.error(err);
+        }
+      });
+    }
 
-    // TODO - check if needs to end
     this.end();
-      */
   }
 
   public connect() {

--- a/src/server/init.sql
+++ b/src/server/init.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS recipe (
+	id binary(16) NOT NULL,
+	uri varchar(500) NOT NULL,
+	label varchar(50) NOT NULL,
+	image varchar(255) NOT NULL,
+	source varchar(255) NOT NULL,
+	url varchar(255) NOT NULL,
+	ingredientsJSON blob,
+	ingredientsLinesJSON blob,
+	PRIMARY KEY (id)
+);
+
+CREATE TABLE if not exists user (
+	id binary(16) NOT NULL,
+    email varchar(255) NOT NULL,
+    name varchar(255) NOT NULL,
+    picture varchar(255) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE if not exists favorited_item (
+    id binary(16) NOT NULL,
+    recipe_id binary(16) NOT NULL,
+    user_id binary(16) NOT NULL,
+    favorited_at date NOT NULL,
+    FOREIGN KEY (recipe_id) REFERENCES recipe(id),
+    FOREIGN KEY (user_id) REFERENCES user(id),
+    PRIMARY KEY (id)
+);


### PR DESCRIPTION
### Changes: 
* Production script 
* Creates tables only when they don't exist
*  Does not have mock insert statements 


### Few changes compared to the initial one: 

* for the ids used `binary(16)` - so we can use it with `UUID` function - see [here](https://www.geek
sforgeeks.org/uuid-function-in-mysql/) and [here](https://www.geeksforgeeks.org/is_uuid-function-in-mysql/) 
* added one more blob for the recipe (see types.ts) 
* changed sizes of some fields
* added foreign keys to the `favorited_recipe`
 